### PR TITLE
feat: highlight brackets using builtin hl-MatchParen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/lua/matchwith/config.lua
+++ b/lua/matchwith/config.lua
@@ -5,54 +5,61 @@ local M = {}
 ---@param opts Options Global options
 ---@return boolean is_ok
 function M.set_options(opts)
-  if not opts then
-    return false
-  end
-  vim.validate({
-    debounce_time = { opts.debounce_time, 'number', true },
-    ignore_filetypes = { opts.ignore_filetypes, 'table', true },
-    ignore_buftypes = { opts.ignore_buftypes, 'table', true },
-    jump_key = { opts.jump_key, 'string', true },
-    captures = { opts.captures, 'table', true },
-    indicator = { opts.indicator, 'number', true },
-    sign = { opts.sign, 'boolean', true },
-    symbols = { opts.symbols, 'table', true },
-  })
-  if opts.debounce_time then
-    vim.g.matchwith_debounce_time = opts.debounce_time
-  end
-  if opts.ignore_filetypes then
-    vim.g.matchwith_ignore_filetypes = vim.list_extend(vim.g.matchwith_ignore_filetypes, opts.ignore_filetypes)
-  end
-  if opts.ignore_buftypes then
-    vim.g.matchwith_ignore_buftypes = vim.list_extend(vim.g.matchwith_ignore_buftypes, opts.ignore_buftypes)
-  end
-  if opts.captures then
-    vim.list_extend(vim.g.matchwith_captures, opts.captures)
-  end
-  if opts.jump_key then
-    vim.cmd('silent! MatchDisable')
-    vim.keymap.set({ 'n', 'x', 'o' }, opts.jump_key, function()
-      return '<Cmd>lua require("matchwith").jumping()<CR>'
-    end, { expr = true, desc = 'Jump cursor to matchpair' })
-  end
-  if opts.indicator and (opts.indicator > 0) then
-    local name = 'NormalFloat'
-    local value = { link = matchwith.hlgroups.off }
-    vim.api.nvim_set_hl(matchwith.ns, name, value)
-    vim.g.matchwith_indicator = opts.indicator
-  end
-  if opts.sign then
-    local name = matchwith.hlgroups.sign
-    local hl_detail = vim.api.nvim_get_hl(0, { name = matchwith.hlgroups.off })
-    hl_detail = vim.tbl_extend('force', hl_detail, { default = true })
-    vim.api.nvim_set_hl(0, name, hl_detail)
-    vim.g.matchwith_sign = opts.sign
-  end
-  if opts.symbols then
-    vim.g.symbols = opts.symbols
-  end
-  return true
+    if not opts then
+        return false
+    end
+    vim.validate({
+        debounce_time = { opts.debounce_time, 'number', true },
+        ignore_filetypes = { opts.ignore_filetypes, 'table', true },
+        ignore_buftypes = { opts.ignore_buftypes, 'table', true },
+        jump_key = { opts.jump_key, 'string', true },
+        captures = { opts.captures, 'table', true },
+        indicator = { opts.indicator, 'number', true },
+        sign = { opts.sign, 'boolean', true },
+        symbols = { opts.symbols, 'table', true },
+    })
+    if opts.debounce_time then
+        vim.g.matchwith_debounce_time = opts.debounce_time
+    end
+    if opts.ignore_filetypes then
+        vim.g.matchwith_ignore_filetypes = vim.list_extend(
+            vim.g.matchwith_ignore_filetypes,
+            opts.ignore_filetypes
+        )
+    end
+    if opts.ignore_buftypes then
+        vim.g.matchwith_ignore_buftypes = vim.list_extend(
+            vim.g.matchwith_ignore_buftypes,
+            opts.ignore_buftypes
+        )
+    end
+    if opts.captures then
+        vim.list_extend(vim.g.matchwith_captures, opts.captures)
+    end
+    if opts.jump_key then
+        vim.cmd('silent! MatchDisable')
+        vim.keymap.set({ 'n', 'x', 'o' }, opts.jump_key, function()
+            return '<Cmd>lua require("matchwith").jumping()<CR>'
+        end, { expr = true, desc = 'Jump cursor to matchpair' })
+    end
+    if opts.indicator and (opts.indicator > 0) then
+        local name = 'NormalFloat'
+        local value = { link = matchwith.hlgroups.off }
+        vim.api.nvim_set_hl(matchwith.ns, name, value)
+        vim.g.matchwith_indicator = opts.indicator
+    end
+    if opts.sign then
+        local name = matchwith.hlgroups.sign
+        local hl_detail =
+            vim.api.nvim_get_hl(0, { name = matchwith.hlgroups.off })
+        hl_detail = vim.tbl_extend('force', hl_detail, { default = true })
+        vim.api.nvim_set_hl(0, name, hl_detail)
+        vim.g.matchwith_sign = opts.sign
+    end
+    if opts.symbols then
+        vim.g.symbols = opts.symbols
+    end
+    return true
 end
 
 return M

--- a/lua/matchwith/init.lua
+++ b/lua/matchwith/init.lua
@@ -1,7 +1,7 @@
 ---@module 'util'
 local util = setmetatable({}, {
     __index = function(t, k)
-        t = package.loaded['fret.util'] or require 'matchwith.util'
+        t = package.loaded['fret.util'] or require('matchwith.util')
         return t[k]
     end,
 })
@@ -61,8 +61,8 @@ function matchwith.new(row, col)
     self['changetick'] = api.nvim_buf_get_changedtick(self.bufnr)
     local pos = api.nvim_win_get_cursor(self.winid)
     -- adjust row to zero-base
-    self['top_row'] = util.zerobase(fn.line 'w0')
-    self['bottom_row'] = util.zerobase(fn.line 'w$')
+    self['top_row'] = util.zerobase(fn.line('w0'))
+    self['bottom_row'] = util.zerobase(fn.line('w$'))
     self['cur_row'] = row or util.zerobase(pos[1])
     self['cur_col'] = col or _adjust_col(self.mode, pos[2])
     self['opt'] = {
@@ -232,7 +232,7 @@ end
 
 -- Get pair range
 function matchwith.get_matchpair(self, match, ranges)
-    local node = match.node
+    local node = assert(match.node)
     local node_range = { node:range() }
     local is_start = _is_start_point(self.cur_row, match.range, node_range)
     -- Query.iter_matches may not be able to get the bracket range, so we need to add it
@@ -459,7 +459,7 @@ function matchwith.jumping()
     end
     if vim.tbl_isempty(cache.last.state) then
         if vim.tbl_isempty(cache.last.line) then
-            vim.cmd 'normal! %'
+            vim.cmd('normal! %')
             return
         end
         local pos = api.nvim_win_get_cursor(0)

--- a/lua/matchwith/init.lua
+++ b/lua/matchwith/init.lua
@@ -1,9 +1,9 @@
 ---@module 'util'
 local util = setmetatable({}, {
-  __index = function(t, k)
-    t = package.loaded['fret.util'] or require('matchwith.util')
-    return t[k]
-  end,
+    __index = function(t, k)
+        t = package.loaded['fret.util'] or require 'matchwith.util'
+        return t[k]
+    end,
 })
 local api = vim.api
 local fn = vim.fn
@@ -12,10 +12,10 @@ local tsq = ts.query
 
 local UNIQ_ID = 'Matchwith-nvim'
 local _cache = {
-  last = { row = vim.NIL, state = {}, line = {} },
-  marker_range = {},
-  skip_matching = false,
-  changetick = 0,
+    last = { row = vim.NIL, state = {}, line = {} },
+    marker_range = {},
+    skip_matching = false,
+    changetick = 0,
 }
 ---@class Cache
 local cache = vim.deepcopy(_cache)
@@ -28,7 +28,7 @@ _G.Matchwith_hlgroup = nil
 
 -- util module hub
 function matchwith.util_call()
-  return util
+    return util
 end
 
 -- Adjust column for insert-mode
@@ -37,8 +37,8 @@ end
 ---@param col integer
 ---@return integer column
 local function _adjust_col(mode, col)
-  local dec = util.is_insert_mode(mode) and 1 or 0
-  return math.max(0, col - dec)
+    local dec = util.is_insert_mode(mode) and 1 or 0
+    return math.max(0, col - dec)
 end
 
 -- Convert range from Range4 to WordRange(row,scol,ecol)
@@ -46,100 +46,114 @@ end
 ---@param node TSNode|Range4
 ---@return WordRange WordRange
 local function _convert_range(node)
-  local row, scol, _, ecol = ts.get_node_range(node)
-  return { row, scol, ecol }
+    local row, scol, _, ecol = ts.get_node_range(node)
+    return { row, scol, ecol }
 end
 
 -- Start a new instance
 function matchwith.new(row, col)
-  local self = setmetatable({}, { __index = matchwith })
-  self['mode'] = api.nvim_get_mode().mode
-  self['bufnr'] = api.nvim_get_current_buf()
-  self['winid'] = api.nvim_get_current_win()
-  self['filetype'] = api.nvim_get_option_value('filetype', { buf = self.bufnr })
-  self['changetick'] = api.nvim_buf_get_changedtick(self.bufnr)
-  local pos = api.nvim_win_get_cursor(self.winid)
-  -- adjust row to zero-base
-  self['top_row'] = util.zerobase(fn.line('w0'))
-  self['bottom_row'] = util.zerobase(fn.line('w$'))
-  self['cur_row'] = row or util.zerobase(pos[1])
-  self['cur_col'] = col or _adjust_col(self.mode, pos[2])
-  self['opt'] = {
-    ignore_filetypes = vim.g.matchwith_ignore_filetypes,
-    captures = vim.g.matchwith_captures,
-    indicator = vim.g.matchwith_indicator,
-    sign = vim.g.matchwith_sign,
-    symbols = vim.g.matchwith_symbols,
-  }
-  return self
+    local self = setmetatable({}, { __index = matchwith })
+    self['mode'] = api.nvim_get_mode().mode
+    self['bufnr'] = api.nvim_get_current_buf()
+    self['winid'] = api.nvim_get_current_win()
+    self['filetype'] =
+        api.nvim_get_option_value('filetype', { buf = self.bufnr })
+    self['changetick'] = api.nvim_buf_get_changedtick(self.bufnr)
+    local pos = api.nvim_win_get_cursor(self.winid)
+    -- adjust row to zero-base
+    self['top_row'] = util.zerobase(fn.line 'w0')
+    self['bottom_row'] = util.zerobase(fn.line 'w$')
+    self['cur_row'] = row or util.zerobase(pos[1])
+    self['cur_col'] = col or _adjust_col(self.mode, pos[2])
+    self['opt'] = {
+        ignore_filetypes = vim.g.matchwith_ignore_filetypes,
+        captures = vim.g.matchwith_captures,
+        indicator = vim.g.matchwith_indicator,
+        sign = vim.g.matchwith_sign,
+        symbols = vim.g.matchwith_symbols,
+    }
+    return self
 end
 
 -- Clear highlights for a matchpair
 function matchwith.clear_ns(self)
-  local clear = false
-  if not vim.tbl_isempty(cache.marker_range) then
-    -- api.nvim_buf_clear_namespace(0, self.ns, cache.marker_range[1], cache.marker_range[2])
-    api.nvim_buf_clear_namespace(0, self.ns, 0, -1)
-    clear = true
-  end
-  return clear
+    local clear = false
+    if not vim.tbl_isempty(cache.marker_range) then
+        -- api.nvim_buf_clear_namespace(0, self.ns, cache.marker_range[1], cache.marker_range[2])
+        api.nvim_buf_clear_namespace(0, self.ns, 0, -1)
+        clear = true
+    end
+    return clear
 end
 
 ---Get match items
 function matchwith.get_matches(self)
-  ---@type MatchItem?, Range4[], Range4[]
-  local match, ranges, line = nil, {}, {}
-  -- TODO: Should handle get_parser return value change in neovim 12.
-  ---@type boolean, vim.treesitter.LanguageTree?
-  local ok, lang_tree
-  if ts._get_parser then
-    lang_tree = ts._get_parser(self.bufnr, self.filetype)
-    if not lang_tree then
-      return match, ranges, line
-    end
-  else
-    ok, lang_tree = pcall(ts.get_parser, self.bufnr, self.filetype)
-    if not ok or not lang_tree then
-      return match, ranges, line
-    end
-  end
-  ---@type integer
-  local ptn
-  lang_tree:for_each_tree(function(tstree, ltree)
-    local tsroot = tstree:root()
-    local root_start_row, _, root_end_row, _ = tsroot:range()
-    if (root_start_row > self.cur_row) or (root_end_row < self.cur_row) then
-      return
-    end
-    local lang = ltree:lang()
-    local queries = tsq.get(lang, 'highlights')
-    if not queries or lang == 'markdown' then
-      return
-    end
-    local iter = queries:iter_matches(tsroot, self.bufnr, self.cur_row, self.cur_row + 1, { all = true })
-    for pattern, matches in iter do
-      for int, nodes in pairs(matches) do
-        local capture = queries.captures[int]
-        if vim.tbl_contains(self.opt.captures, capture) then
-          for _, node in ipairs(nodes) do
-            local tsrange = { node:range() }
-            util.tbl_insert(ranges, pattern, tsrange)
-            if tsrange[1] == self.cur_row then
-              table.insert(line, tsrange)
-              if (tsrange[2] <= self.cur_col) and (tsrange[4] > self.cur_col) then
-                local parent = node:parent()
-                if parent then
-                  match = { node = parent, range = tsrange }
-                  ptn = pattern
-                end
-              end
-            end
-          end
+    ---@type MatchItem?, Range4[], Range4[]
+    local match, ranges, line = nil, {}, {}
+    -- TODO: Should handle get_parser return value change in neovim 12.
+    ---@type boolean, vim.treesitter.LanguageTree?
+    local ok, lang_tree
+    if ts._get_parser then
+        lang_tree = ts._get_parser(self.bufnr, self.filetype)
+        if not lang_tree then
+            return match, ranges, line
         end
-      end
+    else
+        ok, lang_tree = pcall(ts.get_parser, self.bufnr, self.filetype)
+        if not ok or not lang_tree then
+            return match, ranges, line
+        end
     end
-  end)
-  return match, ranges[ptn] or {}, line
+    ---@type integer
+    local ptn
+    lang_tree:for_each_tree(function(tstree, ltree)
+        local tsroot = tstree:root()
+        local root_start_row, _, root_end_row, _ = tsroot:range()
+        if (root_start_row > self.cur_row) or (root_end_row < self.cur_row) then
+            return
+        end
+        local lang = ltree:lang()
+        local queries = tsq.get(lang, 'highlights')
+        if not queries or lang == 'markdown' then
+            return
+        end
+        local iter = queries:iter_matches(
+            tsroot,
+            self.bufnr,
+            self.cur_row,
+            self.cur_row + 1,
+            { all = true }
+        )
+        for pattern, matches in iter do
+            for int, nodes in pairs(matches) do
+                local capture = queries.captures[int]
+                if vim.tbl_contains(self.opt.captures, capture) then
+                    for _, node in ipairs(nodes) do
+                        local tsrange = { node:range() }
+                        util.tbl_insert(ranges, pattern, tsrange)
+                        if tsrange[1] == self.cur_row then
+                            table.insert(line, tsrange)
+                            if
+                                (tsrange[2] <= self.cur_col)
+                                and (tsrange[4] > self.cur_col)
+                            then
+                                local parent = node:parent()
+                                if parent then
+                                    match = {
+                                        node = parent,
+                                        capture = capture,
+                                        range = tsrange,
+                                    }
+                                    ptn = pattern
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end)
+    return match, ranges[ptn] or {}, line
 end
 
 -- Whether the cursor position is at the node starting point
@@ -148,46 +162,51 @@ end
 ---@param parent Range4
 ---@return boolean is_start
 local function _is_start_point(cur_row, current, parent)
-  if cur_row == parent[3] then
-    if current[4] == parent[4] then
-      return true
+    if cur_row == parent[3] then
+        if current[4] == parent[4] then
+            return true
+        end
+        if parent[1] ~= parent[3] then
+            return current[2] == parent[2]
+        end
     end
-    if parent[1] ~= parent[3] then
-      return current[2] == parent[2]
-    end
-  end
-  return false
+    return false
 end
 
 -- Whether the pair's position is on-screen or off-screen
-function matchwith.pair_marker_state(self, is_start, pair)
-  local pair_row, pair_scol, pair_ecol = unpack(pair)
-  local leftcol = fn.winsaveview().leftcol
-  local wincol = fn.wincol()
-  local win_width = api.nvim_win_get_width(self.winid)
-  if api.nvim_get_option_value('list', { win = self.winid }) then
-    local extends, precedes = util.expand_wrap_symbols()
-    win_width = win_width - extends
-    leftcol = leftcol + precedes
-  end
-  local num = 0
-  if pair_scol > self.cur_col then
-    if pair_scol > (self.cur_col + (win_width - wincol)) then
-      num = 3
+function matchwith.pair_marker_state(self, match, pair)
+    local pair_row, pair_scol, pair_ecol = unpack(pair)
+    local leftcol = fn.winsaveview().leftcol
+    local wincol = fn.wincol()
+    local win_width = api.nvim_win_get_width(self.winid)
+    if api.nvim_get_option_value('list', { win = self.winid }) then
+        local extends, precedes = util.expand_wrap_symbols()
+        win_width = win_width - extends
+        leftcol = leftcol + precedes
     end
-  elseif pair_ecol < leftcol then
-    num = 6
-  end
-  local is_over = (num > 0) and (self.cur_row ~= pair_row)
-  if is_start then
-    if is_over or (pair_row < self.top_row) then
-      num = num + 1
+    local num = 0
+    if pair_scol > self.cur_col then
+        if pair_scol > (self.cur_col + (win_width - wincol)) then
+            num = 3
+        end
+    elseif pair_ecol < leftcol then
+        num = 6
     end
-  elseif is_over or (pair_row > self.bottom_row) then
-    num = num + 2
-  end
-  local resp = (num > 0) and { self.hlgroups.off, self.opt.symbols[num] } or { self.hlgroups.on }
-  return resp[1], resp[2]
+    local is_over = (num > 0) and (self.cur_row ~= pair_row)
+    if match.is_start then
+        if is_over or (pair_row < self.top_row) then
+            num = num + 1
+        end
+    elseif is_over or (pair_row > self.bottom_row) then
+        num = num + 2
+    end
+    return num
+end
+
+---@param num integer
+---@return boolean
+local function is_pair_off_screen(num)
+    return num > 0
 end
 
 -- Detect matchpair range
@@ -197,233 +216,287 @@ end
 ---@param count integer
 ---@return Range4|vim.NIL
 local function _find_sibling(is_forward, node, ranges, count)
-  for _ = 1, count, 1 do
-    for _, range in ipairs(ranges) do
-      if not node then
-        return vim.NIL
-      end
-      if vim.deep_equal(range, { node:range() }) then
-        return range
-      end
+    for _ = 1, count, 1 do
+        for _, range in ipairs(ranges) do
+            if not node then
+                return vim.NIL
+            end
+            if vim.deep_equal(range, { node:range() }) then
+                return range
+            end
+        end
+        node = is_forward and node:next_sibling() or node:prev_sibling()
     end
-    node = is_forward and node:next_sibling() or node:prev_sibling()
-  end
-  return vim.NIL
+    return vim.NIL
 end
 
--- Get hlgroup and pair range
+-- Get pair range
 function matchwith.get_matchpair(self, match, ranges)
-  local node = match.node
-  local node_range = { node:range() }
-  local is_start = _is_start_point(self.cur_row, match.range, node_range)
-  -- Query.iter_matches may not be able to get the bracket range, so we need to add it
-  if node_range[1] ~= node_range[3] then
-    local pairspec = is_start and { node_range[1], node_range[2], node_range[1], node_range[2] + 1 }
-      or { node_range[3], node_range[4] - 1, node_range[3], node_range[4] }
-    table.insert(ranges, pairspec)
-  end
-  local count = node:child_count() - 1
-  local pair_range = is_start and _find_sibling(true, node:child(0), ranges, count)
-    or _find_sibling(false, node:child(count), ranges, count)
-  local marker_range = { node_range[1], node_range[3] + 1 }
-  return is_start, pair_range, marker_range
+    local node = match.node
+    local node_range = { node:range() }
+    local is_start = _is_start_point(self.cur_row, match.range, node_range)
+    -- Query.iter_matches may not be able to get the bracket range, so we need to add it
+    if node_range[1] ~= node_range[3] then
+        local pairspec = is_start
+                and {
+                    node_range[1],
+                    node_range[2],
+                    node_range[1],
+                    node_range[2] + 1,
+                }
+            or { node_range[3], node_range[4] - 1, node_range[3], node_range[4] }
+        table.insert(ranges, pairspec)
+    end
+    local count = node:child_count() - 1
+    local pair_range = is_start
+            and _find_sibling(true, node:child(0), ranges, count)
+        or _find_sibling(false, node:child(count), ranges, count)
+    local marker_range = { node_range[1], node_range[3] + 1 }
+    return is_start, pair_range, marker_range
 end
 
 ---Set user-defined matchpairs
 function matchwith.set_userdef()
-  local chars, matchpair = {}, {}
-  vim.tbl_map(function(v)
-    ---@type string,string
-    local s, e = unpack(vim.split(v, ':', { plain = true }))
-    local s_ = s == '[' and '\\[' or s
-    local e_ = e == ']' and '\\]' or e
-    matchpair[s] = { s_, '', e_, 'nW' }
-    matchpair[e] = { s_, '', e_, 'bnW' }
-    vim.list_extend(chars, { e, s })
-  end, vim.split(vim.bo.matchpairs, ',', { plain = true }))
-  cache.userdef = { chars = chars, matchpair = matchpair }
+    local chars, matchpair = {}, {}
+    vim.tbl_map(function(v)
+        ---@type string,string
+        local s, e = unpack(vim.split(v, ':', { plain = true }))
+        local s_ = s == '[' and '\\[' or s
+        local e_ = e == ']' and '\\]' or e
+        matchpair[s] = { s_, '', e_, 'nW' }
+        matchpair[e] = { s_, '', e_, 'bnW' }
+        vim.list_extend(chars, { e, s })
+    end, vim.split(vim.bo.matchpairs, ',', { plain = true }))
+    cache.userdef = { chars = chars, matchpair = matchpair }
 end
 
 function matchwith.clear_userdef()
-  cache.userdef = nil
+    cache.userdef = nil
 end
 
 ---Check user-defined matchpairs
 function matchwith.user_matchpair(self, match, line)
-  local state = {}
-  if not match then
-    local line_str = vim.api.nvim_get_current_line()
-    local search_opts
-    if vim.fn.type(line_str) ~= 10 then
-      local charidx = vim.str_utfindex(line_str, self.cur_col)
-      local char = vim.fn.strcharpart(line_str, charidx, 1)
-      search_opts = cache.userdef.matchpair[char]
-    end
-    if search_opts then
-      local pos = fn.searchpairpos(unpack(search_opts))
-      if (pos[1] + pos[2]) ~= 0 then
-        local row, col = util.zerobase(pos[1]), util.zerobase(pos[2])
-        match = {
-          range = { self.cur_row, self.cur_col, self.cur_row, self.cur_col + 1 },
-          is_start = search_opts[4] == 'nW',
-        }
-        local pair = { row, col, row, col + 1 }
-        state = { match.range, pair }
-      end
-    else
-      local s = self.cur_col + 2
-      local e = line[1] and (line[1][4] - 1) or #line_str
-      if (e - s) > 0 then
-        line_str = line_str:sub(s, e)
-        local iter = vim.iter(cache.userdef.chars)
-        if iter:find(function(v)
-          return line_str:find(v, 1, true)
-        end) then
-          line = {}
+    local state = {}
+    if not match then
+        local line_str = vim.api.nvim_get_current_line()
+        local search_opts
+        if vim.fn.type(line_str) ~= 10 then
+            local charidx = vim.str_utfindex(line_str, self.cur_col)
+            local char = vim.fn.strcharpart(line_str, charidx, 1)
+            search_opts = cache.userdef.matchpair[char]
         end
-      end
+        if search_opts then
+            local pos = fn.searchpairpos(unpack(search_opts))
+            if (pos[1] + pos[2]) ~= 0 then
+                local row, col = util.zerobase(pos[1]), util.zerobase(pos[2])
+                match = {
+                    range = {
+                        self.cur_row,
+                        self.cur_col,
+                        self.cur_row,
+                        self.cur_col + 1,
+                    },
+                    is_start = search_opts[4] == 'nW',
+                }
+                local pair = { row, col, row, col + 1 }
+                state = { match.range, pair }
+            end
+        else
+            local s = self.cur_col + 2
+            local e = line[1] and (line[1][4] - 1) or #line_str
+            if (e - s) > 0 then
+                line_str = line_str:sub(s, e)
+                local iter = vim.iter(cache.userdef.chars)
+                if
+                    iter:find(function(v)
+                        return line_str:find(v, 1, true)
+                    end)
+                then
+                    line = {}
+                end
+            end
+        end
     end
-  end
-  return match, { row = self.cur_row, state = state, line = line }
+    return match,
+        {
+            row = self.cur_row,
+            state = state,
+            line = line,
+            capture = match and match.capture,
+        }
 end
 
-function matchwith.draw_markers(self, is_start, match, pair)
-  local word_range = _convert_range(match)
-  local pair_range = _convert_range(pair)
-  local is_insert = util.is_insert_mode(self.mode)
-  local hlgroup, symbol = self:pair_marker_state(is_start, pair_range)
-  self:add_marker(hlgroup, word_range)
-  self:add_marker(hlgroup, pair_range)
-  if not is_insert and (fn.foldclosed(self.cur_row + 1) == -1) then
-    if hlgroup == self.hlgroups.off then
-      self:set_indicator(symbol)
+function matchwith.draw_markers(self, is_start, match, pair, capture)
+    local word_range = _convert_range(match)
+    local pair_range = _convert_range(pair)
+    local is_insert = util.is_insert_mode(self.mode)
+    local num = self:pair_marker_state(match, pair_range)
+    local on_or_off = is_pair_off_screen(num) and 'off' or 'on'
+    local hlgroup = self.hlgroups[on_or_off] 
+    if not capture or capture == 'punctuation.bracket'  then
+      hlgroup = 'MatchParen' -- no associated capture (matchpairs) or bracket (TS)
     end
-  end
-  return { match, pair }
+    self:add_marker(hlgroup, word_range)
+    self:add_marker(hlgroup, pair_range)
+    if not is_insert and (fn.foldclosed(self.cur_row + 1) == -1) then
+        if hlgroup == self.hlgroups.off then
+            self:set_indicator(self.opt.symbols[num])
+        end
+    end
+    return { match, pair }
 end
 
 function matchwith.add_marker(self, hlgroup, word_range)
-  api.nvim_buf_add_highlight(self.bufnr, self.ns, hlgroup, unpack(word_range))
+    api.nvim_buf_add_highlight(self.bufnr, self.ns, hlgroup, unpack(word_range))
 end
 
 function matchwith.set_indicator(self, symbol)
-  if symbol then
-    if self.opt.sign then
-      local opts = { sign_hl_group = matchwith.hlgroups.sign, sign_text = symbol, priority = 0 }
-      util.ext_sign(self.ns, self.cur_row, self.cur_col, opts)
+    if symbol then
+        if self.opt.sign then
+            local opts = {
+                sign_hl_group = matchwith.hlgroups.sign,
+                sign_text = symbol,
+                priority = 0,
+            }
+            util.ext_sign(self.ns, self.cur_row, self.cur_col, opts)
+        end
+        if self.opt.indicator > 0 then
+            util.indicator(
+                self.ns,
+                symbol,
+                self.opt.indicator,
+                self.cur_row,
+                self.cur_col
+            )
+        end
     end
-    if self.opt.indicator > 0 then
-      util.indicator(self.ns, symbol, self.opt.indicator, self.cur_row, self.cur_col)
-    end
-  end
 end
 
 -- Update matched pairs
 function matchwith.matching(row, col)
-  if vim.g.matchwith_disable or vim.b.matchwith_disable then
-    return
-  end
-  if cache.skip_matching then
-    cache.skip_matching = false
-    return
-  end
+    if vim.g.matchwith_disable or vim.b.matchwith_disable then
+        return
+    end
+    if cache.skip_matching then
+        cache.skip_matching = false
+        return
+    end
 
-  local session = matchwith.new(row, col)
-  if vim.tbl_contains(session.opt.ignore_filetypes, session.filetype) then
-    return
-  end
-  if (session.cur_row == cache.last.row) and (session.changetick == cache.changetick) then
+    local session = matchwith.new(row, col)
+    if vim.tbl_contains(session.opt.ignore_filetypes, session.filetype) then
+        return
+    end
     if
-      not vim.tbl_isempty(cache.last.state)
-      and (cache.last.state[1][2] <= session.cur_col)
-      and (cache.last.state[1][4] > session.cur_col)
+        (session.cur_row == cache.last.row)
+        and (session.changetick == cache.changetick)
     then
-      return
-    end
-  else
-    cache.changetick = session.changetick
-  end
-  local clear_marker = session:clear_ns()
-  if clear_marker then
-    cache.marker_range = {}
-  end
-  if not cache.userdef then
-    matchwith.set_userdef()
-  end
-  local match, ranges, line = session:get_matches()
-  match, cache.last = session:user_matchpair(match, line)
-  if not match then
-    return
-  end
-  if match.is_start ~= nil then
-    cache.marker_range = { session.cur_row, cache.last.state[2][1] + 1 }
-    session:draw_markers(match.is_start, unpack(cache.last.state))
-    return
-  end
-  --TODO: errors for "else" must be addressed
-  -- if #ranges < 2 then
-  --   return
-  -- end
-
-  local is_start, pair_range, marker_range = session:get_matchpair(match, ranges)
-  if pair_range ~= vim.NIL then
-    ---@cast pair_range -vim.NIL
-    cache.marker_range = marker_range
-    if row and col then
-      cache.last.state = { match.range, pair_range }
+        if
+            not vim.tbl_isempty(cache.last.state)
+            and (cache.last.state[1][2] <= session.cur_col)
+            and (cache.last.state[1][4] > session.cur_col)
+        then
+            return
+        end
     else
-      cache.last.state = session:draw_markers(is_start, match.range, pair_range)
+        cache.changetick = session.changetick
     end
-  else
-    cache.last.state = {}
-  end
-  return true
+    local clear_marker = session:clear_ns()
+    if clear_marker then
+        cache.marker_range = {}
+    end
+    if not cache.userdef then
+        matchwith.set_userdef()
+    end
+    local match, ranges, line = session:get_matches()
+    match, cache.last = session:user_matchpair(match, line)
+    if not match then
+        return
+    end
+    if match.is_start ~= nil then
+        cache.marker_range = { session.cur_row, cache.last.state[2][1] + 1 }
+        session:draw_markers(
+            match.is_start,
+            cache.last.state[1],
+            cache.last.state[2],
+            cache.last.capture -- match.capture or cache.last.capture?
+        )
+        return
+    end
+    --TODO: errors for "else" must be addressed
+    -- if #ranges < 2 then
+    --   return
+    -- end
+
+    local is_start, pair_range, marker_range = session:get_matchpair(match, ranges)
+    if pair_range ~= vim.NIL then
+        ---@cast pair_range -vim.NIL
+        cache.marker_range = marker_range
+        if row and col then
+            cache.last.state = { match.range, pair_range }
+            cache.last.capture = match.capture
+        else
+            cache.last.state = session:draw_markers(
+                is_start,
+                match.range,
+                pair_range,
+                match.capture
+            )
+        end
+    else
+        cache.last.state = {}
+    end
+    return true
 end
 
 function matchwith.jumping()
-  local vcount = vim.v.count1
-  if vcount > 1 then
-    vim.cmd(string.format('normal! %s%%', vcount))
-    return
-  end
-  if vim.tbl_isempty(cache.last.state) then
-    if vim.tbl_isempty(cache.last.line) then
-      vim.cmd('normal! %')
-      return
+    local vcount = vim.v.count1
+    if vcount > 1 then
+        vim.cmd(string.format('normal! %s%%', vcount))
+        return
     end
-    local pos = api.nvim_win_get_cursor(0)
-    ---@type boolean?
-    local ok
-    for _, range in ipairs(cache.last.line) do
-      if (range[1] + 1) == pos[1] and (range[2] > pos[2]) then
-        ok = matchwith.matching(range[1], range[2])
-        break
-      end
+    if vim.tbl_isempty(cache.last.state) then
+        if vim.tbl_isempty(cache.last.line) then
+            vim.cmd 'normal! %'
+            return
+        end
+        local pos = api.nvim_win_get_cursor(0)
+        ---@type boolean?
+        local ok
+        for _, range in ipairs(cache.last.line) do
+            if (range[1] + 1) == pos[1] and (range[2] > pos[2]) then
+                ok = matchwith.matching(range[1], range[2])
+                break
+            end
+        end
+        if not ok then
+            return
+        end
     end
-    if not ok then
-      return
+    ---TODO:Need to fix a bug that is causing the switch_statement to not correctly get the range it returns.
+    if vim.tbl_isempty(cache.last.state) then
+        return
     end
-  end
-  ---TODO:Need to fix a bug that is causing the switch_statement to not correctly get the range it returns.
-  if vim.tbl_isempty(cache.last.state) then
-    return
-  end
-  cache.skip_matching = true
-  local row, scol = unpack(cache.last.state[2])
-  api.nvim_win_set_cursor(0, { row + 1, scol })
-  local session = matchwith.new(row, scol)
-  local is_start = cache.last.state[1][1] < cache.last.state[2][1]
-  session:clear_ns()
-  session:draw_markers(is_start, cache.last.state[2], cache.last.state[1])
-  cache.last.state = { [1] = cache.last.state[2], [2] = cache.last.state[1] }
+    cache.skip_matching = true
+    local row, scol = unpack(cache.last.state[2])
+    api.nvim_win_set_cursor(0, { row + 1, scol })
+    local session = matchwith.new(row, scol)
+    local is_start = cache.last.state[1][1] < cache.last.state[2][1]
+    session:clear_ns()
+    session:draw_markers(
+        is_start,
+        cache.last.state[2],
+        cache.last.state[1],
+        cache.last.capture
+    )
+    cache.last.state = { [1] = cache.last.state[2], [2] = cache.last.state[1] }
 end
 
 -- Configure Matchwith settings
 function matchwith.setup(opts)
-  local ok = require('matchwith.config').set_options(opts)
-  if not ok then
-    util.notify(UNIQ_ID, 'Error: Requires arguments', vim.log.levels.ERROR)
-  end
+    local ok = require('matchwith.config').set_options(opts)
+    if not ok then
+        util.notify(UNIQ_ID, 'Error: Requires arguments', vim.log.levels.ERROR)
+    end
 end
 
 return matchwith

--- a/lua/matchwith/init.lua
+++ b/lua/matchwith/init.lua
@@ -347,7 +347,9 @@ function matchwith.draw_markers(self, is_start, match, pair, capture)
 end
 
 function matchwith.add_marker(self, hlgroup, word_range)
-    api.nvim_buf_add_highlight(self.bufnr, self.ns, hlgroup, unpack(word_range))
+    local start = { word_range[1], word_range[2] }
+    local finish = { word_range[1], word_range[3] }
+    vim.hl.range(self.bufnr, self.ns, hlgroup, start, finish)
 end
 
 function matchwith.set_indicator(self, symbol)

--- a/lua/matchwith/init.lua
+++ b/lua/matchwith/init.lua
@@ -331,7 +331,8 @@ function matchwith.draw_markers(self, is_start, match, pair, capture)
     local pair_range = _convert_range(pair)
     local is_insert = util.is_insert_mode(self.mode)
     local num = self:pair_marker_state(is_start, pair_range)
-    local on_or_off = is_pair_off_screen(num) and 'off' or 'on'
+    local pair_off_screen = is_pair_off_screen(num)
+    local on_or_off = pair_off_screen and 'off' or 'on'
     local hlgroup = self.hlgroups[on_or_off]
     if not capture or capture == 'punctuation.bracket' then
         hlgroup = 'MatchParen' -- no associated capture (matchpairs) or bracket (TS)
@@ -339,7 +340,7 @@ function matchwith.draw_markers(self, is_start, match, pair, capture)
     self:add_marker(hlgroup, word_range)
     self:add_marker(hlgroup, pair_range)
     if not is_insert and (fn.foldclosed(self.cur_row + 1) == -1) then
-        if hlgroup == self.hlgroups.off then
+        if pair_off_screen then
             self:set_indicator(self.opt.symbols[num])
         end
     end

--- a/lua/matchwith/init.lua
+++ b/lua/matchwith/init.lua
@@ -174,7 +174,7 @@ local function _is_start_point(cur_row, current, parent)
 end
 
 -- Whether the pair's position is on-screen or off-screen
-function matchwith.pair_marker_state(self, match, pair)
+function matchwith.pair_marker_state(self, is_start, pair)
     local pair_row, pair_scol, pair_ecol = unpack(pair)
     local leftcol = fn.winsaveview().leftcol
     local wincol = fn.wincol()
@@ -193,7 +193,7 @@ function matchwith.pair_marker_state(self, match, pair)
         num = 6
     end
     local is_over = (num > 0) and (self.cur_row ~= pair_row)
-    if match.is_start then
+    if is_start then
         if is_over or (pair_row < self.top_row) then
             num = num + 1
         end
@@ -330,11 +330,11 @@ function matchwith.draw_markers(self, is_start, match, pair, capture)
     local word_range = _convert_range(match)
     local pair_range = _convert_range(pair)
     local is_insert = util.is_insert_mode(self.mode)
-    local num = self:pair_marker_state(match, pair_range)
+    local num = self:pair_marker_state(is_start, pair_range)
     local on_or_off = is_pair_off_screen(num) and 'off' or 'on'
-    local hlgroup = self.hlgroups[on_or_off] 
-    if not capture or capture == 'punctuation.bracket'  then
-      hlgroup = 'MatchParen' -- no associated capture (matchpairs) or bracket (TS)
+    local hlgroup = self.hlgroups[on_or_off]
+    if not capture or capture == 'punctuation.bracket' then
+        hlgroup = 'MatchParen' -- no associated capture (matchpairs) or bracket (TS)
     end
     self:add_marker(hlgroup, word_range)
     self:add_marker(hlgroup, pair_range)
@@ -427,7 +427,8 @@ function matchwith.matching(row, col)
     --   return
     -- end
 
-    local is_start, pair_range, marker_range = session:get_matchpair(match, ranges)
+    local is_start, pair_range, marker_range =
+        session:get_matchpair(match, ranges)
     if pair_range ~= vim.NIL then
         ---@cast pair_range -vim.NIL
         cache.marker_range = marker_range

--- a/lua/matchwith/types.lua
+++ b/lua/matchwith/types.lua
@@ -44,7 +44,7 @@
 ---@field new fun(row?:integer,col?:integer):Matchwith
 ---@field clear_ns fun(self:self):boolean
 ---@field get_matches fun(self:self):MatchItem?,Range4[],Range4[]
----@field pair_marker_state fun(self:self,match:MatchItem,pair:WordRange):integer
+---@field pair_marker_state fun(self:self,is_start:boolean,pair:WordRange):integer
 ---@field get_matchpair fun(self:self,match:MatchItem,ranges:Range4[]):boolean, Range4|vim.NIL,integer[]
 ---@field set_userdef fun():nil
 ---@field clear_userdef fun():nil

--- a/lua/matchwith/types.lua
+++ b/lua/matchwith/types.lua
@@ -1,9 +1,9 @@
----@alias Hlgroup 'Matchwith'|'MatchwithOut'|'MatchwithSign'
+---@alias Hlgroup 'Matchwith'|'MatchwithOut'|'MatchwithSign'|'MatchParen'
 ---@alias HlKeys 'on'|'off'|'sign'
 -- WordRange details 1:`row`, 2:`start_row`, 3:`end_row`
 ---@alias WordRange {[1]:integer,[2]:integer,[3]:integer}
----@alias MatchItem {node:TSNode,range:Range4,is_start?:boolean}
----@alias Last {row:integer|vim.NIL,state:LastState,line:Range4[]}
+---@alias MatchItem {node?:TSNode,range:Range4,is_start?:boolean,capture?:string}
+---@alias Last {row:integer|vim.NIL,state:LastState,line:Range4[],capture?:string}
 ---@alias LastState {[1]:Range4,[2]:Range4}
 ---@alias UserDefined {chars:string[],matchpair:table<string,string[]>}
 
@@ -44,12 +44,12 @@
 ---@field new fun(row?:integer,col?:integer):Matchwith
 ---@field clear_ns fun(self:self):boolean
 ---@field get_matches fun(self:self):MatchItem?,Range4[],Range4[]
----@field pair_marker_state fun(self:self,is_start:boolean,pair:WordRange):string,string|nil
+---@field pair_marker_state fun(self:self,match:MatchItem,pair:WordRange):integer
 ---@field get_matchpair fun(self:self,match:MatchItem,ranges:Range4[]):boolean, Range4|vim.NIL,integer[]
 ---@field set_userdef fun():nil
 ---@field clear_userdef fun():nil
 ---@field user_matchpair fun(self:self,match:MatchItem?,line:Range4[]):MatchItem?,Last
----@field draw_markers fun(self:self,is_start:boolean,match:Range4,pair:Range4):LastState
+---@field draw_markers fun(self:self,is_start:boolean,match:Range4,pair:Range4,capture?:string):LastState
 ---@field add_marker fun(self:self,group:Hlgroup,word_range:WordRange)
 ---@field set_indicator fun(self:self,symbol:string|nil)
 ---@field matching fun(row?:integer,col?:integer):boolean?

--- a/lua/matchwith/types.lua
+++ b/lua/matchwith/types.lua
@@ -51,7 +51,7 @@
 ---@field user_matchpair fun(self:self,match:MatchItem?,line:Range4[]):MatchItem?,Last
 ---@field draw_markers fun(self:self,is_start:boolean,match:Range4,pair:Range4,capture?:string):LastState
 ---@field add_marker fun(self:self,group:Hlgroup,word_range:WordRange)
----@field set_indicator fun(self:self,symbol:string|nil)
+---@field set_indicator fun(self:self,symbol:string?)
 ---@field matching fun(row?:integer,col?:integer):boolean?
 ---@field jumping fun(self:self)
 ---@field setup fun(opts:Matchwith)

--- a/lua/matchwith/util.lua
+++ b/lua/matchwith/util.lua
@@ -11,25 +11,29 @@ local M = {}
 ---@param errorlevel integer
 ---@param options? table
 function M.notify(name, message, errorlevel, options)
-  options = options or {}
-  vim.notify(string.format('[%s] %s', name, message), errorlevel, options)
+    options = options or {}
+    vim.notify(string.format('[%s] %s', name, message), errorlevel, options)
 end
 
 ---@param name string
 ---@param subject string
 ---@param msg string|string[][]
 function M.echo(name, subject, msg)
-  if type(msg) == 'string' then
-    msg = { { msg } }
-  end
-  api.nvim_echo({ { string.format('[%s] %s: ', name, subject) }, unpack(msg) }, false, {})
+    if type(msg) == 'string' then
+        msg = { { msg } }
+    end
+    api.nvim_echo(
+        { { string.format('[%s] %s: ', name, subject) }, unpack(msg) },
+        false,
+        {}
+    )
 end
 
 -- Adjust the number for 0-based
 ---@param int integer
 ---@return integer 0-based integer
 function M.zerobase(int)
-  return int - 1
+    return int - 1
 end
 
 -- Check the number of characters on the display
@@ -37,32 +41,32 @@ end
 ---@param column integer
 ---@return integer charwidth
 function M.charwidth(string, column)
-  return api.nvim_strwidth(fn.strcharpart(string, column, 1))
+    return api.nvim_strwidth(fn.strcharpart(string, column, 1))
 end
 
 -- Expand wrapping symbols
 ---@return integer extends,integer precedes
 function M.expand_wrap_symbols()
-  local listchars = vim.opt.listchars:get()
-  local extends = listchars.extends and 1 or 0
-  local precedes = listchars.precedes and 1 or 0
-  return extends, precedes
+    local listchars = vim.opt.listchars:get()
+    local extends = listchars.extends and 1 or 0
+    local precedes = listchars.precedes and 1 or 0
+    return extends, precedes
 end
 
 -- Determine whether the specified string is in insert-mode.
 ---@parame mode string
 ---@return boolean
 function M.is_insert_mode(mode)
-  return mode:find('^[i|R]') ~= nil
+    return mode:find('^[i|R]') ~= nil
 end
 
 -- Operator-pending or not
 ---@param mode? string
 function M.is_operator(mode)
-  if not mode then
-    mode = api.nvim_get_mode().mode
-  end
-  return mode:find('^no')
+    if not mode then
+        mode = api.nvim_get_mode().mode
+    end
+    return mode:find('^no')
 end
 
 -- Add element to list. If there is no key in the list, create a new key
@@ -70,37 +74,37 @@ end
 ---@param key string|integer
 ---@param ... any
 function M.tbl_insert(tbl, key, ...)
-  local args = { ... }
-  local pos, value
-  if #args < 2 then
-    local idx = tbl[key] and vim.tbl_count(tbl[key]) + 1 or 1
-    table.insert(args, 1, idx)
-  end
-  ---@cast args[1] integer
-  pos, value = unpack(args)
-  if type(tbl) ~= 'table' then
-    tbl = {}
-  end
-  if not tbl[key] then
-    tbl[key] = {}
-  end
-  table.insert(tbl[key], pos, value)
+    local args = { ... }
+    local pos, value
+    if #args < 2 then
+        local idx = tbl[key] and vim.tbl_count(tbl[key]) + 1 or 1
+        table.insert(args, 1, idx)
+    end
+    ---@cast args[1] integer
+    pos, value = unpack(args)
+    if type(tbl) ~= 'table' then
+        tbl = {}
+    end
+    if not tbl[key] then
+        tbl[key] = {}
+    end
+    table.insert(tbl[key], pos, value)
 end
 
 ---@param name string|string[]
 ---@param opts vim.api.keyset.create_autocmd
 ---@param safestate? boolean
 function M.autocmd(name, opts, safestate)
-  local callback = opts.callback
-  opts.pattern = opts.pattern or '*'
-  if safestate then
-    opts.callback = function()
-      opts.once = true
-      opts.callback = callback
-      api.nvim_create_autocmd('SafeState', opts)
+    local callback = opts.callback
+    opts.pattern = opts.pattern or '*'
+    if safestate then
+        opts.callback = function()
+            opts.once = true
+            opts.callback = callback
+            api.nvim_create_autocmd('SafeState', opts)
+        end
     end
-  end
-  api.nvim_create_autocmd(name, opts)
+    api.nvim_create_autocmd(name, opts)
 end
 
 ---@class Timer
@@ -114,74 +118,92 @@ end
 
 ---@return Timer
 function M.set_timer()
-  local timer = assert(uv.new_timer())
-  local running = false
-  return setmetatable({}, {
-    __index = {
-      debounce = function(timeout, callback)
-        if not running then
-          running = true
-        else
-          timer:stop()
-        end
-        timer:start(timeout, 0, function()
-          vim.schedule(callback)
-          running = false
-        end)
-      end,
-      stop = function()
-        if timer and running then
-          timer:stop()
-          running = false
-        end
-      end,
-      close = function()
-        if timer and running then
-          timer:stop()
-          timer:close()
-        end
-      end,
-      _closing = function()
-        return timer:is_closing()
-      end,
-      flash = function(wait, winid, blend, decay)
-        if not running then
-          running = true
-          timer:start(
-            0,
-            wait,
-            vim.schedule_wrap(function()
-              if not api.nvim_win_is_valid(winid) then
-                return
-              end
-              local blending = api.nvim_get_option_value('winblend', { win = winid }) + decay
-              if blending > 100 then
-                blending = 100
-              end
-              api.nvim_set_option_value('winblend', blending, { win = winid })
-              if api.nvim_get_option_value('winblend', { win = winid }) == 100 and timer:is_active() then
-                timer:stop()
-                timer:close()
-                api.nvim_win_close(winid, true)
-              end
-            end)
-          )
-        else
-          api.nvim_set_option_value('winblend', blend, { win = winid })
-        end
-      end,
-    },
-  })
+    local timer = assert(uv.new_timer())
+    local running = false
+    return setmetatable({}, {
+        __index = {
+            debounce = function(timeout, callback)
+                if not running then
+                    running = true
+                else
+                    timer:stop()
+                end
+                timer:start(timeout, 0, function()
+                    vim.schedule(callback)
+                    running = false
+                end)
+            end,
+            stop = function()
+                if timer and running then
+                    timer:stop()
+                    running = false
+                end
+            end,
+            close = function()
+                if timer and running then
+                    timer:stop()
+                    timer:close()
+                end
+            end,
+            _closing = function()
+                return timer:is_closing()
+            end,
+            flash = function(wait, winid, blend, decay)
+                if not running then
+                    running = true
+                    timer:start(
+                        0,
+                        wait,
+                        vim.schedule_wrap(function()
+                            if not api.nvim_win_is_valid(winid) then
+                                return
+                            end
+                            local blending = api.nvim_get_option_value(
+                                'winblend',
+                                { win = winid }
+                            ) + decay
+                            if blending > 100 then
+                                blending = 100
+                            end
+                            api.nvim_set_option_value(
+                                'winblend',
+                                blending,
+                                { win = winid }
+                            )
+                            if
+                                api.nvim_get_option_value(
+                                        'winblend',
+                                        { win = winid }
+                                    )
+                                    == 100
+                                and timer:is_active()
+                            then
+                                timer:stop()
+                                timer:close()
+                                api.nvim_win_close(winid, true)
+                            end
+                        end)
+                    )
+                else
+                    api.nvim_set_option_value(
+                        'winblend',
+                        blend,
+                        { win = winid }
+                    )
+                end
+            end,
+        },
+    })
 end
 
 ---@private
 local float_options = {
-  relative = 'win',
-  height = 1,
-  focusable = false,
-  noautocmd = true,
-  border = false,
-  style = 'minimal',
+    relative = 'win',
+    height = 1,
+    focusable = false,
+    noautocmd = true,
+    border = false,
+    style = 'minimal',
 }
 
 -- Show indicator on cursor
@@ -192,20 +214,20 @@ local float_options = {
 ---@param col integer
 ---@return integer window_handle
 function M.indicator(ns, text, timeout, row, col)
-  local bufnr = api.nvim_create_buf(false, true)
-  local opts = vim.tbl_extend('force', float_options, {
-    width = 1,
-    row = 0,
-    col = 0,
-    bufpos = { row, col },
-  })
-  local winid = api.nvim_open_win(bufnr, false, opts)
-  api.nvim_win_set_hl_ns(winid, ns)
-  api.nvim_buf_set_text(bufnr, 0, 0, 0, 0, { text })
-  vim.defer_fn(function()
-    api.nvim_win_close(winid, true)
-  end, timeout)
-  return winid
+    local bufnr = api.nvim_create_buf(false, true)
+    local opts = vim.tbl_extend('force', float_options, {
+        width = 1,
+        row = 0,
+        col = 0,
+        bufpos = { row, col },
+    })
+    local winid = api.nvim_open_win(bufnr, false, opts)
+    api.nvim_win_set_hl_ns(winid, ns)
+    api.nvim_buf_set_text(bufnr, 0, 0, 0, 0, { text })
+    vim.defer_fn(function()
+        api.nvim_win_close(winid, true)
+    end, timeout)
+    return winid
 end
 
 -- Show indicator on signcolumn
@@ -214,9 +236,9 @@ end
 ---@param col integer
 ---@param opts vim.api.keyset.set_extmark
 function M.ext_sign(ns, row, col, opts)
-  local _opts = { sign_hl_group = 'Normal' }
-  opts = vim.tbl_extend('force', _opts, opts)
-  api.nvim_buf_set_extmark(0, ns, row, col, opts)
+    local _opts = { sign_hl_group = 'Normal' }
+    opts = vim.tbl_extend('force', _opts, opts)
+    api.nvim_buf_set_extmark(0, ns, row, col, opts)
 end
 
 -- Flash pair marker
@@ -225,26 +247,29 @@ end
 ---@param blend integer Initial value of winblend
 ---@param decay integer winblend becay
 function M.beacon(ns, hl, blend, decay)
-  vim.defer_fn(function()
-    local line = api.nvim_get_current_line()
-    local _, col = unpack(api.nvim_win_get_cursor(0))
-    local charidx = vim.str_utfindex(line, col)
-    local charwidth = math.min(2, #vim.fn.strcharpart(line, charidx, 1, true))
-    local next_charwidth = math.min(2, #vim.fn.strcharpart(line, charidx + 1, 1, true))
-    local width = next_charwidth == 0 and charwidth * 3 or charwidth * 2 + next_charwidth
-    local opts = vim.tbl_extend('force', float_options, {
-      width = width,
-      row = vim.fn.winline() - 1,
-      col = vim.fn.wincol() - 1 - charwidth,
-    })
-    local bufnr = api.nvim_create_buf(false, true)
-    local winid = api.nvim_open_win(bufnr, false, opts)
-    api.nvim_win_set_hl_ns(winid, ns)
-    vim.wo[winid].winhl = ('Normal:%s'):format(hl)
-    api.nvim_set_option_value('winblend', blend, { win = winid })
-    local timer = M.set_timer()
-    timer.flash(80, winid, blend, decay)
-  end, 0)
+    vim.defer_fn(function()
+        local line = api.nvim_get_current_line()
+        local _, col = unpack(api.nvim_win_get_cursor(0))
+        local charidx = vim.str_utfindex(line, col)
+        local charwidth =
+            math.min(2, #vim.fn.strcharpart(line, charidx, 1, true))
+        local next_charwidth =
+            math.min(2, #vim.fn.strcharpart(line, charidx + 1, 1, true))
+        local width = next_charwidth == 0 and charwidth * 3
+            or charwidth * 2 + next_charwidth
+        local opts = vim.tbl_extend('force', float_options, {
+            width = width,
+            row = vim.fn.winline() - 1,
+            col = vim.fn.wincol() - 1 - charwidth,
+        })
+        local bufnr = api.nvim_create_buf(false, true)
+        local winid = api.nvim_open_win(bufnr, false, opts)
+        api.nvim_win_set_hl_ns(winid, ns)
+        vim.wo[winid].winhl = ('Normal:%s'):format(hl)
+        api.nvim_set_option_value('winblend', blend, { win = winid })
+        local timer = M.set_timer()
+        timer.flash(80, winid, blend, decay)
+    end, 0)
 end
 
 return M

--- a/plugin/matchwith.lua
+++ b/plugin/matchwith.lua
@@ -1,18 +1,26 @@
 if vim.g.loaded_matchwith then
-  return
+    return
 end
 
 vim.g.loaded_matchwith = true
 
 local UNIQ_ID = 'Matchwith-nvim'
 local HLGROUP = {
-  on = 'Matchwith',
-  off = 'MatchwithOut',
-  sign = 'MatchwithSign',
+    on = 'Matchwith',
+    off = 'MatchwithOut',
+    sign = 'MatchwithSign',
 }
 local hl_detail = {
-  [HLGROUP.on] = { default = true, fg = vim.api.nvim_get_hl(0, { name = 'MatchParen' }).fg, bg = 'NONE' },
-  [HLGROUP.off] = { default = true, fg = vim.api.nvim_get_hl(0, { name = 'Error' }).fg, bg = 'NONE' },
+    [HLGROUP.on] = {
+        default = true,
+        fg = vim.api.nvim_get_hl(0, { name = 'MatchParen' }).fg,
+        bg = 'NONE',
+    },
+    [HLGROUP.off] = {
+        default = true,
+        fg = vim.api.nvim_get_hl(0, { name = 'Error' }).fg,
+        bg = 'NONE',
+    },
 }
 
 _G.Matchwith_hlgroup = HLGROUP
@@ -21,9 +29,22 @@ vim.g.matchwith_indicator = 0
 vim.g.matchwith_sign = false
 vim.g.matchwith_ignore_filetypes = { 'vimdoc' }
 vim.g.matchwith_ignore_buftypes = { 'nofile' }
-vim.g.matchwith_captures = { 'keyword.function', 'keyword.repeat', 'keyword.conditional', 'punctuation.bracket' }
-vim.g.matchwith_symbols =
-  { [1] = '↑', [2] = '↓', [3] = '→', [4] = '↗', [5] = '↘', [6] = '←', [7] = '↖', [8] = '↙' }
+vim.g.matchwith_captures = {
+    'keyword.function',
+    'keyword.repeat',
+    'keyword.conditional',
+    'punctuation.bracket',
+}
+vim.g.matchwith_symbols = {
+    [1] = '↑',
+    [2] = '↓',
+    [3] = '→',
+    [4] = '↗',
+    [5] = '↘',
+    [6] = '←',
+    [7] = '↖',
+    [8] = '↙',
+}
 
 -- local util = package.loaded['fret.util'] or require('matchwith.util')
 local matchwith = require('matchwith')
@@ -32,56 +53,57 @@ local timer = util.set_timer()
 local augroup = vim.api.nvim_create_augroup(UNIQ_ID, { clear = true })
 
 local function set_hl()
-  for name, value in pairs(hl_detail) do
-    vim.api.nvim_set_hl(0, name, value)
-  end
+    for name, value in pairs(hl_detail) do
+        vim.api.nvim_set_hl(0, name, value)
+    end
 end
 
 util.autocmd('BufEnter', {
-  desc = 'Matchwith ignore buftypes',
-  group = augroup,
-  callback = function()
-    if vim.b.matchwith_disable or (vim.bo.buftype ~= '') then
-      return
-    end
-    vim.b.matchwith_disable = vim.tbl_contains(vim.g.matchwith_ignore_buftypes, vim.bo.buftype)
-    matchwith.clear_userdef()
-  end,
+    desc = 'Matchwith ignore buftypes',
+    group = augroup,
+    callback = function()
+        if vim.b.matchwith_disable or (vim.bo.buftype ~= '') then
+            return
+        end
+        vim.b.matchwith_disable =
+            vim.tbl_contains(vim.g.matchwith_ignore_buftypes, vim.bo.buftype)
+        matchwith.clear_userdef()
+    end,
 })
 
 util.autocmd({ 'CursorMoved', 'CursorMovedI' }, {
-  desc = 'Update matchpair highlight',
-  group = augroup,
-  callback = function()
-    timer.debounce(vim.g.matchwith_debounce_time, function()
-      matchwith.matching()
-    end)
-  end,
+    desc = 'Update matchpair highlight',
+    group = augroup,
+    callback = function()
+        timer.debounce(vim.g.matchwith_debounce_time, function()
+            matchwith.matching()
+        end)
+    end,
 })
 
 util.autocmd({ 'InsertEnter', 'InsertLeave' }, {
-  desc = 'Update matchpair highlight',
-  group = augroup,
-  callback = function()
-    matchwith.matching()
-  end,
+    desc = 'Update matchpair highlight',
+    group = augroup,
+    callback = function()
+        matchwith.matching()
+    end,
 })
 
 util.autocmd({ 'OptionSet' }, {
-  desc = 'Reset matchwith userdef',
-  group = augroup,
-  pattern = { 'matchpairs' },
-  callback = function()
-    matchwith.set_userdef()
-  end,
+    desc = 'Reset matchwith userdef',
+    group = augroup,
+    pattern = { 'matchpairs' },
+    callback = function()
+        matchwith.set_userdef()
+    end,
 })
 
 util.autocmd({ 'ColorScheme' }, {
-  desc = 'Reload matchwith hlgroups',
-  group = augroup,
-  callback = function()
-    set_hl()
-  end,
+    desc = 'Reload matchwith hlgroups',
+    group = augroup,
+    callback = function()
+        set_hl()
+    end,
 }, true)
 
 vim.cmd('silent! NoMatchParen')

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,4 @@
+column_width = 80
+call_parentheses = "Always"
+indent_type = "Spaces"
+quote_style = "ForceSingle"


### PR DESCRIPTION
I am coming from https://github.com/monkoose/matchparen.nvim which uses the builtin `:h hl-MatchParen` highlight group for brackets. I overall like your plugin better as it provides a more complete feature set and therefore better user experience by also highlighting other TS captures. It works really well for me. However, I found that having the same highlight group for TS nodes and brackets makes it hard to find a good highlight style that would fit both.

In my case I want to keep the original symbol color for TS nodes like this and just use a subtle highlight of the background:

<img width="510" alt="highlight Lua function" src="https://github.com/user-attachments/assets/f6781253-3715-4626-9b50-55aed0b5cc8a" />


But for brackets I want to continue using a more distinct highlight in a different color that makes it easier to spot the matching bracket.

<img width="544" alt="highlight brackets like builtin matchparens" src="https://github.com/user-attachments/assets/b7c4ed49-8434-4830-8362-c51ec35b74be" />



With this PR I tried to implement it by myself and decided to reuse the existing `MatchParen` highlight group since that's supported by all colorschemes out of the box.

Please let me know what you think

side note: I couldn't find a formatter config and I noticed too late that stylua ran automatically, so in the end I added a config for it. Let me know in case I should revert that and there's a different formatter config I can use.